### PR TITLE
Add Nodemon to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "swagger-parser": "^8.0.1"
   },
   "devDependencies": {
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "nodemon": "^1.19.3"
   }
 }


### PR DESCRIPTION
The `dev` command depends on `nodemon` but it is not installed, thus, running
    `npm run dev / yarn dev` will throw an error unless the user has `nodemon` installed globally.
    
    https://github.com/RamirezAlex/cygger/blob/3b23adf5b676be347b9a0d9d6c3f424b8e2d7826/package.json#L10